### PR TITLE
Windows Friendliness

### DIFF
--- a/js/packageUtils.js
+++ b/js/packageUtils.js
@@ -58,7 +58,7 @@ function getFolderAndFilename(path, extension, type) {
 }
 function getFolderAndFilenameWithExt(path, type) {
     if (path) {
-        var seperator = _path.sep + 'src' + _path.sep + type + _path.sep
+        var seperator = '/src/' + type + '/'
         var start = path.indexOf(escape(seperator)) + seperator.length;
         var end = path.length
         var ret = path.substring(start, end)

--- a/js/packageUtils.js
+++ b/js/packageUtils.js
@@ -43,8 +43,8 @@ function getFilename(path, extension) {
 }
 function getFolderAndFilename(path, extension, type) {
     if (path && extension) {
-        var seperator = _path.sep + 'src' + _path.sep + type + _path.sep
-        var start = path.indexOf(escape(seperator)) + seperator.length;
+        var seperator = '/src/' + type + '/'
+        var start = path.indexOf(seperator) + seperator.length;
         var end = path.lastIndexOf(extension) - 1
         if(end > start){
             var ret = path.substring(start, end)
@@ -59,7 +59,7 @@ function getFolderAndFilename(path, extension, type) {
 function getFolderAndFilenameWithExt(path, type) {
     if (path) {
         var seperator = '/src/' + type + '/'
-        var start = path.indexOf(escape(seperator)) + seperator.length;
+        var start = path.indexOf(seperator) + seperator.length;
         var end = path.length
         var ret = path.substring(start, end)
         return ret

--- a/js/packageUtils.js
+++ b/js/packageUtils.js
@@ -48,9 +48,11 @@ function getFolderAndFilename(path, extension, type) {
         var end = path.lastIndexOf(extension) - 1
         if(end > start){
             var ret = path.substring(start, end)
+            ret = ret.replace(/\\/g, "/");
             return ret
         } else {
             var ret = path.substring(start)
+            ret = ret.replace(/\\/g, "/");
             return ret
         }
     }
@@ -62,6 +64,7 @@ function getFolderAndFilenameWithExt(path, type) {
         var start = path.indexOf(seperator) + seperator.length;
         var end = path.length
         var ret = path.substring(start, end)
+        ret = ret.replace(/\\/g, "/");
         return ret
     }
     return ''


### PR DESCRIPTION
On windows, if the path separator is escaped the package.xml is built with full operating system paths leading up to the file name.

Additionally, when folders/paths for things like dashboards, reports, and email templates are built in the package.xml - when using _path, we get windows backslashes.  Salesforce does not seem to understand these, and does not properly place the metadata items in their folders.

The hardcoded forward slash feels safe on any OS, since that's what SFDC understands.