### PR TITLE
Fixing Escalation, Assignment and Auto-Response

### DIFF
--- a/js/metadata_map.json
+++ b/js/metadata_map.json
@@ -60,7 +60,7 @@
     ],
     "autoResponseRules": [
         {
-            "type": "AutoResponseRules",
+            "type": "AutoResponseRule",
             "class": "MetadataXmlElementParser",
             "star": true,
             "description": "Represents an auto-response rule that sets conditions for sending automatic email responses to lead or case submissions based on the attributes of the submitted record.",
@@ -73,7 +73,7 @@
     ],
     "assignmentRules": [
         {
-            "type": "AssignmentRules",
+            "type": "AssignmentRule",
             "class": "MetadataXmlElementParser",
             "star": true,
             "description": "Represents assignment rules that allow you to automatically route cases to the appropriate users or queues.",
@@ -221,6 +221,19 @@
             "description": "",
             "version": "",
             "extension": "email"
+        }
+    ],
+    "escalationRules": [
+        {
+            "type": "EscalationRule",
+            "class": "MetadataXmlElementParser",
+            "star": true,
+            "description": "Represents escalation rules that allow you to automatically route cases to the appropriate users or queues.",
+            "version": "27",
+            "extension": "escalationRules",
+            "options": {
+                "item_xpath": "./xmlns:escalationRule/xmlns:fullName"
+            }
         }
     ],
     "flexipages": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-xml",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Build a Salesforce Package.xml file from a src directory",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Per [Metadata API Dev Guide:](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/manifest_samples.htm)

> Assignment rules, auto-response rules and escalation rules use different package.xml type names to access sets of rules or individual rules for object types. 

> The following sample package.xml manifest file illustrates how to access just the “samplerule” Case assignment rule and the “newrule” Lead assignment rule. Notice that the type name is `AssignmentRule` and not `AssignmentRules`.

>imilarly, for accessing individual auto-response rules and escalation rules, use `AutoResponseRule` and `EscalationRule` instead of `AutoResponseRules` and `EscalationRules`.
