### PR TITLE
Update object detection and include folder metadata

### DIFF
--- a/js/metadata_map.json
+++ b/js/metadata_map.json
@@ -405,7 +405,10 @@
             "type": "CustomObject",
             "class": "CustomObjectParser",
             "description": "Services Custom objects, Article Types, and Custom Medatadata Types",
-            "extension": "object"
+            "extension": "object",
+            "options": {
+                "item_xpath": "./xmlns:label"
+            }
         },
         {
             "type": "BusinessProcess",

--- a/js/packageUtils.js
+++ b/js/packageUtils.js
@@ -48,11 +48,11 @@ function getFolderAndFilename(path, extension, type) {
         var end = path.lastIndexOf(extension) - 1
         if(end > start){
             var ret = path.substring(start, end)
-            ret = ret.replace(/\\/g, "/");
+            ret = ret.replace(/\\/g, "/").replace(/-meta.xml/g, "")
             return ret
         } else {
             var ret = path.substring(start)
-            ret = ret.replace(/\\/g, "/");
+            ret = ret.replace(/\\/g, "/").replace(/-meta.xml/g, "")
             return ret
         }
     }
@@ -65,7 +65,7 @@ function getFolderAndFilenameWithExt(path, type) {
         var start = path.indexOf(seperator) + seperator.length;
         var end = path.length
         var ret = path.substring(start, end)
-        ret = ret.replace(/\\/g, "/");
+        ret = ret.replace(/\\/g, "/").replace(/-meta.xml/g, "")
         return ret
     }
     return ''

--- a/js/parsers.js
+++ b/js/parsers.js
@@ -45,7 +45,7 @@ function isMetadataXmlMatch(file, metadata) {
     return isBaseMatch(file, metadata) && isFile(file)
 }
 function isCustomObjectMatch(file, metadata, managed) {
-    return (managed || !isManagedObjectFilter(file)) && isCustomObjectFilter(file) && isFileExtensionMatch(file, metadata)
+    return (managed || !isManagedObjectFilter(file)) && isCustomObjectFilter(file, metadata) && isFileExtensionMatch(file, metadata)
 }
 // ====================================================================================================
 // ======================================      Filter     ===========================================
@@ -56,8 +56,9 @@ function unmanagedElementFilter(element) {
 function isManagedObjectFilter(file) {
     return file.path.match(/__[\s\S]*__/)
 }
-function isCustomObjectFilter(file) {
-    return file.path.match(/__c.object$/) || file.path.match(/__mdt.object$/) || file.path.match(/__kav.object$/) || file.path.match(/__e.object$/) || file.path.match(/__b.object$/)
+function isCustomObjectFilter(file, metadata) {
+    return (file.path.match(/__c.object$/) || file.path.match(/__mdt.object$/) || file.path.match(/__kav.object$/) || 
+        file.path.match(/__e.object$/) || file.path.match(/__b.object$/)) && getXmlElements(file, metadata).length > 0
 }
 function customElementFilter(element, metadata) {
     var customOnlyTypes = ['CustomField']


### PR DESCRIPTION
This fixes a case in which a partial object file is added to the manifest. If there is a members node in the CustomObject section but the object file does not contain a label node, deploys will fail. 

Also adds folder metadata files. For instance, if ./src/email contains a directory named "Common", and a file exists ./src/email/Common-meta.xml, this will add a members node to the EmailTemplate section with the text node "Common"